### PR TITLE
[FEATURE] Add option insensitive case

### DIFF
--- a/AuthCAS/AuthCAS.php
+++ b/AuthCAS/AuthCAS.php
@@ -195,7 +195,7 @@ class AuthCAS extends AuthPluginBase
         //force CAS authentication
         phpCAS::forceAuthentication();
 
-        // Put the user coming from phpCAS in lowercase (insensitive)
+        // Put the user coming from phpCAS in lowercase
         $cas_userid_to_lowercase = $this->get('casUserIdToLowercase');
         if ($cas_userid_to_lowercase)
         {
@@ -390,6 +390,7 @@ class AuthCAS extends AuthPluginBase
                     $cas_context = $this->get('casAuthUri');
                     $cas_version = $this->get('casVersion');
                     $cas_port = (int) $this->get('casAuthPort');
+                    $cas_userid_to_lowercase = $this->get('casUserIdToLowercase');
                     // Initialize phpCAS
                     //phpCAS::client($cas_version, $cas_host, $cas_port, $cas_context, false);
                     // disable SSL validation of the CAS server
@@ -404,6 +405,14 @@ class AuthCAS extends AuthPluginBase
                     return;
                 }
                 $oUser = new User;
+                // Put the user coming from phpCAS in lowercase
+                if ($cas_userid_to_lowercase)
+                {
+                    $oUser->users_name = strtolower(phpCAS::getUser());
+                } else
+                {
+                    $oUser->users_name = phpCAS::getUser();
+                }
                 $oUser->users_name = phpCAS::getUser();
                 $oUser->password = hash('sha256', createPassword());
                 $oUser->full_name = $cas_fullname;

--- a/AuthCAS/AuthCAS.php
+++ b/AuthCAS/AuthCAS.php
@@ -28,6 +28,11 @@ class AuthCAS extends AuthPluginBase
             'options' => array("1.0" => "CAS_VERSION_1_0", "2.0" => "CAS_VERSION_2_0", "3.0" => "CAS_VERSION_3_0", "S1" => "SAML_VERSION_1_1"),
             'default' => "2.0",
         ),
+        'casUserIdCaseInsensitive' => array(
+            'type' => 'boolean',
+            'label' => 'Make the user ID case insensitive when logging in (save the user ID in lowercase in the database)',
+            'default' => '0'
+        ),
         'autoCreate' => array(
             'type' => 'select',
             'label' => 'Enable automated creation of user ?',
@@ -190,7 +195,15 @@ class AuthCAS extends AuthPluginBase
         //force CAS authentication
         phpCAS::forceAuthentication();
 
-        $this->setUsername(phpCAS::getUser());
+        // Put the user coming from phpCAS in lowercase (insensitive)
+        $cas_userid_insensitive = phpCAS::getAttribute($this->get('casUserIdCaseInsensitive'));
+        if ($cas_userid_insensitive)
+        {
+            $this->setUsername(strtolower(phpCAS::getUser()));
+        } else
+        {
+            $this->setUsername(phpCAS::getUser());
+        }
         $oUser = $this->api->getUserByName($this->getUserName());
         if ($oUser || ((int) $this->get('autoCreate') > 0) ) 
         {
@@ -234,8 +247,16 @@ class AuthCAS extends AuthPluginBase
                 $usersearchbase = $this->get('usersearchbase');
                 $binddn = $this->get('binddn');
                 $bindpwd = $this->get('bindpwd');
-
-                $username = $sUser;
+                $casuseridcaseinsensitive = $this->get('casUserIdCaseInsensitive');
+                
+                // Put the username coming from phpCAS in lowercase (insensitive)                
+                if ($casuseridcaseinsensitive)
+                {
+                    $username = strtolower($sUser);
+                } else
+                {
+                    $username = $sUser;
+                }
 
                 if (empty($ldapport)) 
                 {

--- a/AuthCAS/AuthCAS.php
+++ b/AuthCAS/AuthCAS.php
@@ -28,9 +28,9 @@ class AuthCAS extends AuthPluginBase
             'options' => array("1.0" => "CAS_VERSION_1_0", "2.0" => "CAS_VERSION_2_0", "3.0" => "CAS_VERSION_3_0", "S1" => "SAML_VERSION_1_1"),
             'default' => "2.0",
         ),
-        'casUserIdCaseInsensitive' => array(
+        'casUserIdToLowercase' => array(
             'type' => 'boolean',
-            'label' => 'Make the user ID case insensitive when logging in (save the user ID in lowercase in the database)',
+            'label' => 'Store the user ID in lowercase in the database to avoid issue with case',
             'default' => '0'
         ),
         'autoCreate' => array(
@@ -196,8 +196,8 @@ class AuthCAS extends AuthPluginBase
         phpCAS::forceAuthentication();
 
         // Put the user coming from phpCAS in lowercase (insensitive)
-        $cas_userid_insensitive = phpCAS::getAttribute($this->get('casUserIdCaseInsensitive'));
-        if ($cas_userid_insensitive)
+        $cas_userid_to_lowercase = $this->get('casUserIdToLowercase');
+        if ($cas_userid_to_lowercase)
         {
             $this->setUsername(strtolower(phpCAS::getUser()));
         } else
@@ -247,10 +247,10 @@ class AuthCAS extends AuthPluginBase
                 $usersearchbase = $this->get('usersearchbase');
                 $binddn = $this->get('binddn');
                 $bindpwd = $this->get('bindpwd');
-                $casuseridcaseinsensitive = $this->get('casUserIdCaseInsensitive');
+                $casuseridtolowercase = $this->get('casUserIdToLowercase');
                 
-                // Put the username coming from phpCAS in lowercase (insensitive)                
-                if ($casuseridcaseinsensitive)
+                // Put the username coming from phpCAS in lowercase             
+                if ($casuseridtolowercase)
                 {
                     $username = strtolower($sUser);
                 } else


### PR DESCRIPTION
Allows to put the user ID in lowercase when authenticating by the CAS plugin